### PR TITLE
Dockerfile: upgraded to latest mainline nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN apt-get update && \
         supervisor \
         nano
 
-# Install latest nginx-stable
-RUN add-apt-repository ppa:nginx/stable -y && \
+# Install latest nginx (development PPA is actually mainline development)
+RUN add-apt-repository ppa:nginx/development -y && \
     apt-get update -yq && \
-    apt-get install -yq nginx=1.8.0-1+trusty1
+    apt-get install -yq nginx
 
 # Overlay the root filesystem from this repo
 COPY ./container/root /


### PR DESCRIPTION
Not for merge at this time

- As discussed IRL, updates to the nginx version are *locked* to an actual build in docker hub. It becomes an image
- Updating the version of nginx requires a PR or forcible rebuild of an image tag on docker hub