### PR TITLE
Nginx: use SIGQUIT instead of SIGTERM for graceful shutdown

### DIFF
--- a/container/root/etc/services-available/nginx/finish
+++ b/container/root/etc/services-available/nginx/finish
@@ -1,7 +1,11 @@
 #!/usr/bin/execlineb -S1
 
 # @see https://github.com/just-containers/s6-overlay/issues/101
+
+# Rely on container platform to restart this container on crash (marathon/docker-swarm/kubernetes)
+# BUT, when container is SIGNALLED to stop, don't interfere
 if { s6-test ${1} -ne 0 }
 if { s6-test ${1} -ne 256 }
 
+# When nginx process dies, the container should come down with it
 s6-svscanctl -t /var/run/s6/services

--- a/container/root/etc/services-available/nginx/run
+++ b/container/root/etc/services-available/nginx/run
@@ -1,4 +1,18 @@
 #!/usr/bin/execlineb -P
-s6-setuidgid www-data
 
-nginx -g "daemon off;"
+# @see https://github.com/just-containers/s6-overlay/issues/41#issuecomment-99366363
+
+# Nginx uses SIGQUIT to gracefully stop serving traffic.
+trap -x
+{
+  term
+  {
+    foreground
+    {
+      nginx -s quit
+    }
+    echo [sigterm-nginx] graceful shutdown complete
+  }
+}
+
+s6-setuidgid www-data nginx -g "daemon off;"


### PR DESCRIPTION
- [x] SIGTERM is propagated to nginx as a quit (rewritten as nginx command)
- [x] nginx crash still takes down container