### PR TITLE
Dockerfile: added unprivileged port to ENV variables (as constant)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ MAINTAINER Bryan Latten <latten@adobe.com>
 # Used with alternative CMD (worker.sh), leverages supervisor to maintain long-running processes
 ENV SIGNAL_BUILD_STOP=99 \
     CONTAINER_ROLE=web \
+    CONTAINER_PORT=8080 \
     CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
     CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
     NOT_ROOT_USER=www-data \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     S6_KILL_FINISH_MAXTIME=5000 \
     S6_KILL_GRACETIME=3000
-
 
 # Ensure base system is up to date
 RUN apt-get update && \
@@ -46,10 +46,12 @@ COPY ./container/root /
 
 # Add S6 overlay build, to avoid having to build from source
 RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
-    rm /tmp/s6-overlay-amd64.tar.gz
+    rm /tmp/s6-overlay-amd64.tar.gz && \
+    # Set nginx to listen on defined port \
+    sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE
 
 # Using a non-privileged port to prevent having to use setcap internally
-EXPOSE 8080
+EXPOSE ${CONTAINER_PORT}
 
 # NOTE: intentionally NOT using s6 init as the entrypoint
 # This would prevent container debugging if any of those service crash

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # docker-nginx
 Provides base OS, patches and stable nginx for quick and easy spinup.
-Integrates S6 process supervisor for zombie reaping (as PID 1) and boot coordination.
+Integrates S6 process supervisor `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation
+
+
 @see https://github.com/just-containers/s6-overlay
 
 ### Expectations
 
 Applications using this as a container parent must copy their html/app into the `/var/www/html` folder
 NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
-
 
 
 ### Environment Variables


### PR DESCRIPTION
Allow downstream recipients to not have to know which port it is