### PR TITLE
Dockerfile: optional move to alpine

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,46 @@
+FROM alpine:3.4
+MAINTAINER Bryan Latten <latten@adobe.com>
+
+# Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed
+# Used with alternative CMD (worker.sh), leverages supervisor to maintain long-running processes
+ENV SIGNAL_BUILD_STOP=99 \
+    CONTAINER_ROLE=web \
+    CONTAINER_PORT=8080 \
+    CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
+    CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
+    NOT_ROOT_USER=www-data \
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    S6_KILL_FINISH_MAXTIME=5000 \
+    S6_KILL_GRACETIME=3000
+
+# Create an unprivileged user
+RUN adduser -D -S -H $NOT_ROOT_USER
+
+RUN apk update && \
+    apk add \
+        sed \
+        bash \
+        grep \
+        nginx \
+    && \
+    rm -rf /var/cache/apk/*
+
+# Overlay the root filesystem from this repo
+COPY ./container/root /
+
+# Add S6 overlay build, to avoid having to build from source
+RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
+    rm /tmp/s6-overlay-amd64.tar.gz && \
+    # Set nginx to listen on defined port \
+    sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
+    # Fix permissions to run unprivileged
+    bash -c "chown www-data:www-data /var/{lib,log}/nginx -Rh" && \
+    bash -c "chmod 0755 -R /var/{lib,log}/nginx"
+
+
+# Using a non-privileged port to prevent having to use setcap internally
+EXPOSE ${CONTAINER_PORT}
+
+# NOTE: intentionally NOT using s6 init as the entrypoint
+# This would prevent container debugging if any of those service crash
+CMD ["/bin/bash", "/run.sh"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # docker-nginx
+
+https://hub.docker.com/r/behance/docker-nginx/tags/
+
+Ubuntu used by default, Alpine builds also available tagged as `-alpine`
+
+
 Provides base OS, patches and stable nginx for quick and easy spinup.
 Integrates S6 process supervisor `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation
 

--- a/container/root/etc/nginx/nginx.conf
+++ b/container/root/etc/nginx/nginx.conf
@@ -4,7 +4,7 @@
 # at build time.
 #
 # For run-time replacements, ie, consuming environment vars,
-# add to the run.d/nginx script
+# add to the /etc/cont-init.d/nginx script
 #############################################################
 
 # Only set when running with superuser permissions, otherwise causes a warning

--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -1,6 +1,8 @@
 server {
   listen 8080;
 
+  root /var/www/html;
+
   # Doesn't broadcast version level of server software
   server_tokens off;
 

--- a/container/root/var/www/html/index.html
+++ b/container/root/var/www/html/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
+
+
+<h1>It Works!</h1>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+ubuntu:
+  build: .
+  ports:
+   - '8080:8080'
+  environment:
+    SERVER_LOG_MINIMAL: 1
+    SERVER_APP_NAME: docker-test
+    S6_KILL_FINISH_MAXTIME: 1
+    S6_KILL_GRACETIME: 1
+alpine:
+  build: .
+  dockerfile: Dockerfile-alpine
+  ports:
+   - '8081:8080'
+  environment:
+    SERVER_LOG_MINIMAL: 1
+    SERVER_APP_NAME: docker-test
+    S6_KILL_FINISH_MAXTIME: 1
+    S6_KILL_GRACETIME: 1


### PR DESCRIPTION
Will be trigger via Docker Hub's alternate Dockerfile build system, while remaining in master!

Appears in Docker Hub as behance/docker-nginx:5.0-alpine