### PR TITLE
Dockerfile: working around AUFS permission bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,8 @@ RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     # Set nginx to listen on defined port \
     sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE
 
-RUN goss -g goss.nginx.yaml validate
+RUN goss -g goss.nginx.yaml validate && \
+    /tmp/aufs_hack.sh
 
 # Using a non-privileged port to prevent having to use setcap internally
 EXPOSE ${CONTAINER_PORT}

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -41,7 +41,8 @@ RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     bash -c "chown www-data:www-data /var/{lib,log}/nginx -Rh" && \
     bash -c "chmod 0755 -R /var/{lib,log}/nginx"
 
-RUN goss -g goss.nginx.yaml validate
+RUN goss -g goss.nginx.yaml validate && \
+    /tmp/aufs_hack.sh
 
 # Using a non-privileged port to prevent having to use setcap internally
 EXPOSE ${CONTAINER_PORT}

--- a/container/root/tmp/aufs_hack.sh
+++ b/container/root/tmp/aufs_hack.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Use this to wipe the temp files/folders generated when `nginx -t`
+# NOTE: must be run after a goss test!
+#
+# @see https://github.com/docker/docker/issues/20240
+#
+# In some versions of AUFS, permissions do not set/inherit properly.
+# This can cause folders that are created in a different layer than
+# they are used to not properly respect permissions.
+#
+# For example, when testing nginx's configuration, the temp folders
+# are generated, but cannot be accessed by nginx while running.
+
+echo "[hack] removing test nginx files and folders"
+
+rm -rfv \
+  /tmp/.nginx/client_body \
+  /tmp/.nginx/fastcgi_temp \
+  /tmp/.nginx/scgi_temp \
+  /tmp/.nginx/uwsgi_temp \
+  /tmp/.nginx/proxy_temp \
+  /tmp/.nginx/nginx.pid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ ubuntu:
     S6_KILL_GRACETIME: 1
   volumes:
    - ./container/root/goss.nginx.yaml:/goss.nginx.yaml
+   - ./container/root/var/www/html:/var/www/html
 alpine:
   build: .
   dockerfile: Dockerfile-alpine


### PR DESCRIPTION
Mostly seen downstream when using nginx as fastcgi proxy