### PR TITLE
Goss: fixed tests to be downstream compatible

### DIFF
--- a/container/root/tests/nginx/base.goss.yaml
+++ b/container/root/tests/nginx/base.goss.yaml
@@ -11,24 +11,14 @@ group:
 command:
   nginx -v:
     exit-status: 0
-    stderr: []
+    stderr: ['nginx/1.']
+    stdout: ['!/./']
   nginx -t:
     exit-status: 0
-    stderr: []
+    stderr: ['is ok']
+    stdout: ['!/./']
 
 file:
-  /etc/nginx/sites-available/default:
-    exists: true
-    contains:
-      - listen 8080;
-      - root /var/www/html;
-      - index index.html index.htm;
-      - client_max_body_size 1m;
-      - try_files $uri $uri/ =404;
-      - location ~ /\. {
-      - access_log off;
-      - log_not_found off;
-      - deny all;
   /etc/nginx/nginx.conf:
     exists: true
     contains:
@@ -51,8 +41,8 @@ file:
       - '/#{0}tcp_nodelay\s*on;/'
       - '/#{0}tcp_nopush\s*on;/'
       - '/#{0}include\s*mime.types;/'
-      - '/#{0}default_type  application/octet-stream;/'
-      - '/#{0}access_log /dev/stdout main;/'
+      - '/#{0}default_type\s*application/octet-stream;/'
+      - '/#{0}access_log\s*/dev/stdout\s*main;/'
       - '/#{0}sendfile\s*on;/'
       - '/#{0}keepalive_timeout\s*\d+;/'
       - '/#{0}client_body_temp_path\s*/tmp/.nginx/client_body;/'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ ubuntu:
     SERVER_LARGE_CLIENT_HEADER_BUFFERS: 8 16k
     SERVER_CLIENT_BODY_BUFFER_SIZE: 128k
   volumes:
-   - ./container/root/goss.nginx.yaml:/goss.nginx.yaml
+   - ./container/root/tests/nginx/base.goss.yaml:/tests/nginx/base.goss.yaml
    - ./container/root/var/www/html:/var/www/html
 alpine:
   build: .
@@ -25,3 +25,6 @@ alpine:
     S6_KILL_FINISH_MAXTIME: 1
     S6_KILL_GRACETIME: 1
     SERVER_WORKER_PROCESSES: 1
+  volumes:
+   - ./container/root/tests/nginx/base.goss.yaml:/tests/nginx/base.goss.yaml
+   - ./container/root/var/www/html:/var/www/html


### PR DESCRIPTION
Can't explicitly test only for specific (and local) nginx site settings, since these tests are also run from downstream clients, who apply their own config.

Also fixed testing volume mounts.