### PR TITLE
Move secure headers include to nginx.conf

### DIFF
--- a/container/root/etc/nginx/nginx.conf
+++ b/container/root/etc/nginx/nginx.conf
@@ -32,6 +32,12 @@ events {
 }
 
 http {
+    # Add Secure Headers.
+    # Note that if add_header is called further downstream, all headers defined here must be redefined in that downstream client block
+    # See link below for more details:
+    # @link https://blog.g3rt.nl/nginx-add_header-pitfall.html
+    include /etc/nginx/http_headers.conf;
+
     # Doesn't broadcast version level of server software
     # @link http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
     server_tokens off;

--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -1,8 +1,6 @@
 server {
   listen 8080;
 
-  include /etc/nginx/http_headers.conf;
-
   root /var/www/html;
 
   # Doesn't broadcast version level of server software

--- a/container/root/tests/nginx/base.goss.yaml
+++ b/container/root/tests/nginx/base.goss.yaml
@@ -51,7 +51,7 @@ file:
       - '/#{0}scgi_temp_path\s*/tmp/.nginx/scgi_temp;/'
       - '/#{0}uwsgi_temp_path\s*/tmp/.nginx/uwsgi_temp;/'
       - '/#{0}include\s*\/etc\/nginx\/sites-available\/\*;/'
-      - '/#{0}include\s+\/etc\/nginx\/http_headers.conf;/'
+      - '    include /etc/nginx/http_headers.conf;'
 
 file:
   /etc/nginx/http_headers.conf:


### PR DESCRIPTION
Moving the http header includes to /etc/nginx/nginx.conf into the http block, as this block is usually not overridden by downstream containers.
