### PR TITLE
Enable SSL termination for the container for local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM behance/docker-base:1.6
 MAINTAINER Bryan Latten <latten@adobe.com>
 
-ARG CONTAINER_PORT=8080
-ARG CONTAINER_SSL
-
 ENV CONTAINER_ROLE=web \
+    CONTAINER_PORT=8080 \
     CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
     CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
     NOT_ROOT_USER=www-data
@@ -41,9 +39,6 @@ RUN /bin/bash -e /security_updates.sh && \
 
 # Overlay the root filesystem from this repo
 COPY ./container/root /
-
-# Uncomment the ssl directives
-RUN /bin/bash -c 'if [[ $CONTAINER_SSL ]]; then sed -ig "s/^[ ]*#ssl/  ssl/" $CONF_NGINX_SITE; fi;'
 
 # Set nginx to listen on defined port
 # NOTE: order of operations is important, new config had to already installed from repo (above)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN /bin/bash -e /security_updates.sh && \
     apt-get update -yqq && \
     apt-get install -yqq --no-install-recommends \
         nginx-light \
-    && \
-    apt-get install -yqq --no-install-recommends \
         ca-certificates \
     && \
     # Perform cleanup, ensure unnecessary packages are removed \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -18,8 +18,6 @@ RUN adduser -D -S -H $NOT_ROOT_USER
 RUN apk update --no-cache && \
     apk add \
         nginx \
-    && \
-    apk add \
         ca-certificates \
     && \
     /bin/bash -e /clean.sh

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -19,6 +19,9 @@ RUN apk update --no-cache && \
     apk add \
         nginx \
     && \
+    apk add \
+        ca-certificates \
+    && \
     /bin/bash -e /clean.sh
 
 # Overlay the root filesystem from this repo

--- a/README.md
+++ b/README.md
@@ -7,22 +7,28 @@ Ubuntu used by default, Alpine builds also available tagged as `-alpine`
 
 Provides base OS, patches and stable nginx for quick and easy spinup.
 
-[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation  
+[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation
 
-[Goss](https://github.com/aelsabbahy/goss) is used for build-time testing.  
+[Goss](https://github.com/aelsabbahy/goss) is used for build-time testing.
 
-See parent(s) [docker-base](https://github.com/behance/docker-base) for additional configuration  
+See parent(s) [docker-base](https://github.com/behance/docker-base) for additional configuration
 
 
 ### Expectations
 
 Applications using this as a container parent must copy their html/app into the `/var/www/html` folder
-NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
+NOTE: Nginx is exposed and bound to an unprivileged port, `8080`, by default
 
 
 ### Security
 
 For Ubuntu-based variants, a convenience script is provided for security-only package updates. To run: `/bin/bash -e /security_updates.sh`
+
+### Dockerfile arguments
+Variable | Example | Description
+--- | --- | ---
+`CONTAINER_PORT` | `CONTAINER_PORT=8080` | Allows the runtime to listen on a different port. For example, set it to 8443 would be typical for HTTPS.
+`CONTAINER_SSL` | `CONTAINER_SSL=` | Enable SSL directives in default configuration (Not working @alshamma)
 
 
 ### Environment Variables
@@ -43,6 +49,7 @@ Variable | Example | Description
 `SERVER_LOG_MINIMAL` | `SERVER_LOG_MINIMAL=1` | Minimize the logging format, appropriate for development environments
 `S6_KILL_FINISH_MAXTIME` | `S6_KILL_FINISH_MAXTIME=1000` | Wait time (in ms) for zombie reaping before sending a kill signal
 `S6_KILL_GRACETIME` | `S6_KILL_GRACETIME=500` | Wait time (in ms) for S6 finish scripts before sending kill signal
+`SERVER_ENABLE_SSL` | `SERVER_ENABLE_SSL=` | Enable SSL directives in default configuration (@alshamma: remove this before merge)
 
 
 ### Startup/Runtime Modification
@@ -51,6 +58,19 @@ To inject changes just before runtime, shell scripts (ending in .sh) may be plac
 `/etc/cont-init.d` folder. For example, the above environment variables are used to drive nginx configuration at runtime.
 As part of the process manager, these scripts are run in advance of the supervised processes. @see https://github.com/just-containers/s6-overlay#executing-initialization-andor-finalization-tasks
 
+### HTTPS support for local development
+
+Follow these steps to create an image and run a container that hosts a static website or a service using nginx.
+
+* On your development machine, download or generate an x509 certificate and key appropriate for use with apache or nginx. Install these with the names certificate.crt and certificate.key, respectively, in a local folder.
+* Add an entry to your /etc/hosts to map 127.0.0.1 to the server host name corresponding to your certificate.
+* Build an image using --build-args CONTAINER_PORT=8443 --build-args CONTAINER_SSL=true
+* Start a container using:
+  * -v {folder-containing-certificate.crt/key}:/etc/nginx/certs:ro
+  * -p 443:8443 (or whatever ports you are using)
+* Test
+  * curl https://{your-server-hostname}, or,
+  * curl -k https://localhost
 
 ### Advanced Modification
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Ubuntu used by default, Alpine builds also available tagged as `-alpine`
 
 Provides base OS, patches and stable nginx for quick and easy spinup.
 
-[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation
+[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation 
 
-[Goss](https://github.com/aelsabbahy/goss) is used for build-time testing.
+[Goss](https://github.com/aelsabbahy/goss) is used for build-time testing. 
 
-See parent(s) [docker-base](https://github.com/behance/docker-base) for additional configuration
+See parent(s) [docker-base](https://github.com/behance/docker-base) for additional configuration 
 
 
 ### Expectations
@@ -23,6 +23,7 @@ NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
 ### Security
 
 For Ubuntu-based variants, a convenience script is provided for security-only package updates. To run: `/bin/bash -e /security_updates.sh`
+
 
 ### Environment Variables
 
@@ -59,7 +60,8 @@ Follow these steps to create an image and run a container that hosts a static we
 * Add an entry to your /etc/hosts to map 127.0.0.1 to the server host name corresponding to your certificate.
 * Run the image using --env SERVER_ENABLE_SSL=true
 * Start a container using:
-  * -v {folder-containing-certificate.crt/key}:/etc/nginx/certs:ro
+  * -v {folder-containing-certificate.crt}:/etc/nginx/certs:ro
+  * -v {folder-containing-certificate.key}:/etc/nginx/certs:ro
   * -p 443:8080 (or whatever host port you are using)
 * Test
   * curl https://{your-server-hostname}, or,

--- a/README.md
+++ b/README.md
@@ -17,19 +17,12 @@ See parent(s) [docker-base](https://github.com/behance/docker-base) for addition
 ### Expectations
 
 Applications using this as a container parent must copy their html/app into the `/var/www/html` folder
-NOTE: Nginx is exposed and bound to an unprivileged port, `8080`, by default
+NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
 
 
 ### Security
 
 For Ubuntu-based variants, a convenience script is provided for security-only package updates. To run: `/bin/bash -e /security_updates.sh`
-
-### Dockerfile arguments
-Variable | Example | Description
---- | --- | ---
-`CONTAINER_PORT` | `CONTAINER_PORT=8080` | Allows the runtime to listen on a different port. For example, set it to 8443 would be typical for HTTPS.
-`CONTAINER_SSL` | `CONTAINER_SSL=` | Enable SSL directives in default configuration (Not working @alshamma)
-
 
 ### Environment Variables
 
@@ -49,7 +42,7 @@ Variable | Example | Description
 `SERVER_LOG_MINIMAL` | `SERVER_LOG_MINIMAL=1` | Minimize the logging format, appropriate for development environments
 `S6_KILL_FINISH_MAXTIME` | `S6_KILL_FINISH_MAXTIME=1000` | Wait time (in ms) for zombie reaping before sending a kill signal
 `S6_KILL_GRACETIME` | `S6_KILL_GRACETIME=500` | Wait time (in ms) for S6 finish scripts before sending kill signal
-`SERVER_ENABLE_SSL` | `SERVER_ENABLE_SSL=` | Enable SSL directives in default configuration (@alshamma: remove this before merge)
+`SERVER_ENABLE_SSL` | `SERVER_ENABLE_SSL=` | Enable SSL directives in default configuration
 
 
 ### Startup/Runtime Modification
@@ -58,16 +51,16 @@ To inject changes just before runtime, shell scripts (ending in .sh) may be plac
 `/etc/cont-init.d` folder. For example, the above environment variables are used to drive nginx configuration at runtime.
 As part of the process manager, these scripts are run in advance of the supervised processes. @see https://github.com/just-containers/s6-overlay#executing-initialization-andor-finalization-tasks
 
-### HTTPS support for local development
+### HTTPS/SSL support for local development
 
 Follow these steps to create an image and run a container that hosts a static website or a service using nginx.
 
 * On your development machine, download or generate an x509 certificate and key appropriate for use with apache or nginx. Install these with the names certificate.crt and certificate.key, respectively, in a local folder.
 * Add an entry to your /etc/hosts to map 127.0.0.1 to the server host name corresponding to your certificate.
-* Build an image using --build-args CONTAINER_PORT=8443 --build-args CONTAINER_SSL=true
+* Run the image using --env SERVER_ENABLE_SSL=true
 * Start a container using:
   * -v {folder-containing-certificate.crt/key}:/etc/nginx/certs:ro
-  * -p 443:8443 (or whatever ports you are using)
+  * -p 443:8080 (or whatever host port you are using)
 * Test
   * curl https://{your-server-hostname}, or,
   * curl -k https://localhost

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Ubuntu used by default, Alpine builds also available tagged as `-alpine`
 
 Provides base OS, patches and stable nginx for quick and easy spinup.
 
-[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation 
+[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation  
 
-[Goss](https://github.com/aelsabbahy/goss) is used for build-time testing. 
+[Goss](https://github.com/aelsabbahy/goss) is used for build-time testing.  
 
-See parent(s) [docker-base](https://github.com/behance/docker-base) for additional configuration 
+See parent(s) [docker-base](https://github.com/behance/docker-base) for additional configuration  
 
 
 ### Expectations

--- a/container/root/etc/cont-init.d/10-nginx.sh
+++ b/container/root/etc/cont-init.d/10-nginx.sh
@@ -74,3 +74,10 @@ then
   echo "[nginx] setting client_body_buffer_size to ${SERVER_CLIENT_BODY_BUFFER_SIZE}"
   sed -i "s/client_body_buffer_size .*;/client_body_buffer_size ${SERVER_CLIENT_BODY_BUFFER_SIZE};/" $CONF_NGINX_SERVER
 fi
+
+# if [[ $SERVER_ENABLE_SSL ]]
+# then
+#   echo "[nginx] enabling ssl"
+#   sed -ig "s/^[ ]*#ssl/  ssl/" $CONF_NGINX_SITE
+# fi
+

--- a/container/root/etc/cont-init.d/10-nginx.sh
+++ b/container/root/etc/cont-init.d/10-nginx.sh
@@ -75,9 +75,9 @@ then
   sed -i "s/client_body_buffer_size .*;/client_body_buffer_size ${SERVER_CLIENT_BODY_BUFFER_SIZE};/" $CONF_NGINX_SERVER
 fi
 
-# if [[ $SERVER_ENABLE_SSL ]]
-# then
-#   echo "[nginx] enabling ssl"
-#   sed -ig "s/^[ ]*#ssl/  ssl/" $CONF_NGINX_SITE
-# fi
+if [[ $SERVER_ENABLE_SSL ]]
+then
+  echo "[nginx] enabling ssl"
+  sed -ig "s/^[ ]*#ssl/  ssl/" $CONF_NGINX_SITE
+fi
 

--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -2,7 +2,7 @@ server {
   listen 8080;
 
   #ssl on;
-  #ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  #ssl_protocols TLSv1.2;
   #ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
   ######ssl_dhparam /etc/nginx/certs/dhparams.pem;
   #ssl_prefer_server_ciphers on;

--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -1,6 +1,15 @@
 server {
   listen 8080;
 
+  #ssl on;
+  #ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  #ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+  ######ssl_dhparam /etc/nginx/certs/dhparams.pem;
+  #ssl_prefer_server_ciphers on;
+  #ssl_session_cache shared:SSL:10m;
+  #ssl_certificate /etc/nginx/certs/certificate.crt;
+  #ssl_certificate_key /etc/nginx/certs/certificate.key;
+
   root /var/www/html;
 
   # Doesn't broadcast version level of server software


### PR DESCRIPTION
@bryanlatten Still WIP. I ended up doing two implementations, and prefer the one using CONTAINER_SSL and CONTAINER_PORT. I would remove the SERVER_ENABLE_SSL implementation. 

The tests currently fail if you use --build-args CONTAINER_SSL=true with this problem, although I can run with https on the container: 

$ nginx -t
nginx: [warn] conflicting server name "" on 0.0.0.0:8080, ignored

I have deferred working on alpine while still being reviewed. 
