### PR TITLE
chmod: changing from s6 to standard tool

### DIFF
--- a/container/root/etc/cont-init.d/01-stdout.sh
+++ b/container/root/etc/cont-init.d/01-stdout.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bash
+
+# STDOUT happens to be a very special "file" that is has Docker magic applied to it
+# Unfortunately, permissions are flaky between builds, sometimes causing unprivileged users
+# to hit issues when attempting to write to STDOUT
+
+# Hack: add others read/write back in at runtime :/
+chmod o+rw /dev/stdout

--- a/container/root/etc/fix-attrs.d/01-stdout
+++ b/container/root/etc/fix-attrs.d/01-stdout
@@ -1,1 +1,0 @@
-/dev/stdout false www-data 0644 2700


### PR DESCRIPTION
The S6 tool, for some reason, had issues running in selinux + user namespaces on CoreOS with Docker 1.12+