### PR TITLE
Nginx: running master process back at root

### DIFF
--- a/container/root/etc/cont-init.d/01-stdout.sh
+++ b/container/root/etc/cont-init.d/01-stdout.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/with-contenv bash
-
-# STDOUT happens to be a very special "file" that is has Docker magic applied to it
-# Unfortunately, permissions are flaky between builds, sometimes causing unprivileged users
-# to hit issues when attempting to write to STDOUT
-
-# Hack: add others read/write back in at runtime :/
-chmod o+rw /dev/stdout

--- a/container/root/etc/fix-attrs.d/02-tmp
+++ b/container/root/etc/fix-attrs.d/02-tmp
@@ -1,3 +1,0 @@
-/tmp/.nginx true www-data 0644 2700
-/tmp true www-data 0644 2700
-/var/log/nginx/error.log true www-data 0644 2700

--- a/container/root/etc/nginx/nginx.conf
+++ b/container/root/etc/nginx/nginx.conf
@@ -7,8 +7,8 @@
 # add to the /etc/cont-init.d/nginx script
 #############################################################
 
-# Only set when running with superuser permissions, otherwise causes a warning
-# user www-data;
+# Running workers as non-root users
+user www-data;
 
 worker_processes auto;
 

--- a/container/root/etc/services-available/nginx/run
+++ b/container/root/etc/services-available/nginx/run
@@ -15,4 +15,4 @@ trap -x
   }
 }
 
-s6-setuidgid www-data nginx -g "daemon off;"
+nginx -g "daemon off;"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ ubuntu:
    - '8080:8080'
   environment:
     SERVER_LOG_MINIMAL: 1
-    SERVER_APP_NAME: docker-test
+    SERVER_APP_NAME: docker-ubuntu
     S6_KILL_FINISH_MAXTIME: 1
     S6_KILL_GRACETIME: 1
     SERVER_WORKER_PROCESSES: 1
@@ -21,7 +21,7 @@ alpine:
    - '8081:8080'
   environment:
     SERVER_LOG_MINIMAL: 1
-    SERVER_APP_NAME: docker-test
+    SERVER_APP_NAME: docker-alpine
     S6_KILL_FINISH_MAXTIME: 1
     S6_KILL_GRACETIME: 1
     SERVER_WORKER_PROCESSES: 1


### PR DESCRIPTION
Removing /dev/stdout hacks in order to make this work. Unnecessary precaution for unconnected master process, further mitigated with user namespaces going forward.

Works around: 
- https://github.com/docker/docker/issues/31243
- https://github.com/docker/docker/issues/31106

Allow running in Docker 1.12+ with user namespaces enabled and selinux in enforcing mode