### PR TITLE
Feature: ubuntu v1.13.12-1+xenial0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN /bin/bash -e /security_updates.sh && \
     && \
     add-apt-repository ppa:nginx/development -y && \
     apt-get update -yqq && \
-    apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -yqq \
-        nginx-light \
+    apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -yqq --no-install-recommends \
+    nginx-light libnginx-mod-http-echo nginx-common libc6 libpcre3 libssl1.0.0 zlib1g \
     && \
     apt-get remove --purge -yq \
         manpages \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN /bin/bash -e /security_updates.sh && \
     && \
     add-apt-repository ppa:nginx/development -y && \
     apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
+    apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -yqq \
         nginx-light \
     && \
     apt-get remove --purge -yq \


### PR DESCRIPTION
# nginx/development ppa updated last night around 22 hrs ago
https://launchpad.net/~nginx/+archive/ubuntu/development

Caused the following issue:

```
Setting up nginx-common (1.13.12-1+xenial0) ...

Configuration file '/etc/nginx/nginx.conf'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** nginx.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package nginx-common (--configure):
 end of file on stdin at conffile prompt
dpkg: dependency problems prevent configuration of libnginx-mod-http-echo:
 libnginx-mod-http-echo depends on nginx-common (= 1.13.12-1+xenial0); however:
  Package nginx-common is not configured yet.

dpkg: error processing package libnginx-mod-http-echo (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of nginx-light:
 nginx-light depends on libnginx-mod-http-echo (= 1.13.12-1+xenial0); however:
  Package libnginx-mod-http-echo is not configured yet.
 nginx-light depends on nginx-common (= 1.13.12-1+xenial0); however:
  Package nginx-common is not configured yet.

dpkg: error processing package nginx-light (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of libnginx-mod-http-ndk:
 libnginx-mod-http-ndk depends on nginx-common (= 1.13.12-1+xenial0); however:
  Package nginx-common is not configured yet.

dpkg: error processing package libnginx-mod-http-ndk (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of libnginx-mod-http-lua:
 libnginx-mod-http-lua depends on libnginx-mod-http-ndk (= 1.13.12-1+xenial0); however:
  Package libnginx-mod-http-ndk is not configured yet.
 libnginx-mod-http-lua depends on nginx-common (= 1.13.12-1+xenial0); however:
  Package nginx-common is not configured yet.

dpkg: error processing package libnginx-mod-http-lua (--configure):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.23-0ubuntu10) ...
Errors were encountered while processing:
 nginx-common
 libnginx-mod-http-echo
 nginx-light
 libnginx-mod-http-ndk
 libnginx-mod-http-lua
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
This fixes it.


# Also, one thing to note ... apt-get remove --purge -yq python* ends up removing a couple things that we might not want to lose .. notably all of the openssl/ca-certificates packages.

```
The following packages were automatically installed and are no longer required:
  ca-certificates distro-info-data gir1.2-glib-2.0 iso-codes libapt-inst2.0
  libasn1-8-heimdal libcurl3-gnutls libdbus-1-3 libdbus-glib-1-2 libexpat1
  libffi6 libgirepository-1.0-1 libglib2.0-0 libgmp10 libgnutls30
  libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal
  libheimntlm0-heimdal libhogweed4 libhx509-5-heimdal libidn11 libk5crypto3
  libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2
  libmpdec2 libnettle6 libp11-kit0 libpython3-stdlib libpython3.5-minimal
  libpython3.5-stdlib libroken18-heimdal librtmp1 libsasl2-2
  libsasl2-modules-db libsqlite3-0 libtasn1-6 libwind0-heimdal mime-support
  openssl
Use 'apt autoremove' to remove them.
The following packages will be REMOVED:
  dh-python* lsb-release* python-apt-common* python3* python3-apt*
  python3-dbus* python3-gi* python3-minimal* python3-pycurl*
  python3-software-properties* python3.5* python3.5-minimal*
  software-properties-common*
0 upgraded, 0 newly installed, 13 to remove and 11 not upgraded.
After this operation, 12.4 MB disk space will be freed.
(Reading database ... 6421 files and directories currently installed.)
Removing software-properties-common (0.96.20.7) ...
Purging configuration files for software-properties-common (0.96.20.7) ...
Removing python3-software-properties (0.96.20.7) ...
Removing lsb-release (9.20160110ubuntu0.2) ...
Purging configuration files for lsb-release (9.20160110ubuntu0.2) ...
Removing python3-apt (1.1.0~beta1ubuntu0.16.04.1) ...
Removing python-apt-common (1.1.0~beta1ubuntu0.16.04.1) ...
Removing python3-dbus (1.2.0-3) ...
Removing python3-gi (3.20.0-0ubuntu1) ...
Removing python3-pycurl (7.43.0-1ubuntu1) ...
Removing python3 (3.5.1-3) ...
Purging configuration files for python3 (3.5.1-3) ...
Removing python3-minimal (3.5.1-3) ...
Removing python3.5 (3.5.2-2ubuntu0~16.04.4) ...
Removing python3.5-minimal (3.5.2-2ubuntu0~16.04.4) ...
Unlinking and removing bytecode for runtime python3.5
Purging configuration files for python3.5-minimal (3.5.2-2ubuntu0~16.04.4) ...
Removing dh-python (2.20151103ubuntu1.1) ...
dpkg: warning: while removing dh-python, directory '/usr/share/dh-python/dhpython/build' not empty so not removed
Processing triggers for libc-bin (2.23-0ubuntu10) ...
Processing triggers for mime-support (3.59ubuntu1) ...
Reading package lists...
Building dependency tree...
Reading state information...
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  ca-certificates distro-info-data gir1.2-glib-2.0 iso-codes libapt-inst2.0
  libasn1-8-heimdal libcurl3-gnutls libdbus-1-3 libdbus-glib-1-2 libexpat1
  libffi6 libgirepository-1.0-1 libglib2.0-0 libgmp10 libgnutls30
  libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal
  libheimntlm0-heimdal libhogweed4 libhx509-5-heimdal libidn11 libk5crypto3
  libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2
  libmpdec2 libnettle6 libp11-kit0 libpython3-stdlib libpython3.5-minimal
  libpython3.5-stdlib libroken18-heimdal librtmp1 libsasl2-2
  libsasl2-modules-db libsqlite3-0 libtasn1-6 libwind0-heimdal mime-support
  openssl
```