### PR TITLE
SIGHUP: ignore on terminal disconnect

### DIFF
--- a/container/root/etc/services-available/nginx/run
+++ b/container/root/etc/services-available/nginx/run
@@ -13,6 +13,10 @@ trap -x
     }
     echo [sigterm-nginx] graceful shutdown complete
   }
+  hup
+  {
+    echo [signhup-nginx] received, ignored
+  }
 }
 
 nginx -g "daemon off;"


### PR DESCRIPTION
Also, removed duplicate gitkeep file for folder

Prevents extraneous error message triggered by SIGHUP being sent before SIGTERM, causing a duplicate shutdown