### PR TITLE
Add Dockerfile-njs with helper scripts/add_js_module.sh.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         - Dockerfile: Dockerfile
         - Dockerfile: Dockerfile-alpine
         - Dockerfile: Dockerfile-centos
+        - Dockerfile: Dockerfile-njs
         platform:
         - linux/amd64
         - linux/arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
           suffix: alpine
         - Dockerfile: Dockerfile-centos
           suffix: centos
+        - Dockerfile: Dockerfile-njs
+          suffix: njs
     steps:
       -
         name: Checkout

--- a/Dockerfile-njs
+++ b/Dockerfile-njs
@@ -1,0 +1,63 @@
+FROM behance/docker-base:4.0-ubuntu-20.04
+
+# Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed
+# Used with alternative CMD (worker.sh), leverages supervisor to maintain long-running processes
+ENV CONTAINER_ROLE=web \
+    CONTAINER_PORT=8080 \
+    CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
+    CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
+    NOT_ROOT_USER=www-data \
+    S6_KILL_FINISH_MAXTIME=55000
+
+# Using a non-privileged port to prevent having to use setcap internally
+EXPOSE ${CONTAINER_PORT}
+
+# - Update security packages, plus ca-certificates required for https
+# - Install pre-reqs
+# - Install latest nginx (development PPA is actually mainline development)
+# - Perform cleanup, ensure unnecessary packages are removed
+RUN /bin/bash -e /security_updates.sh && \
+    apt-get install --no-install-recommends -yqq \
+        curl \
+        gnupg2 \
+        software-properties-common \
+    && \
+    sh -c 'export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 && curl -s https://nginx.org/keys/nginx_signing.key | apt-key add -' \
+    && \
+    sh -c 'echo "deb http://nginx.org/packages/ubuntu/ focal nginx" >> /etc/apt/sources.list.d/nginx.list' \
+    && \
+    apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        nginx \
+        nginx-module-njs \
+        ca-certificates \
+    && \
+    apt-get remove --purge -yq \
+        curl \
+        gnupg2 \
+        manpages \
+        manpages-dev \
+        man-db \
+        patch \
+        make \
+        unattended-upgrades \
+        python* \
+    && \
+    /bin/bash -e /clean.sh
+
+# Overlay the root filesystem from this repo
+COPY --chown=www-data ./container/root /
+
+# Set nginx to listen on defined port
+# NOTE: order of operations is important, new config had to already installed from repo (above)
+# - Make temp directory for .nginx runtime files
+# - Fix woff mime type support
+# Set permissions to allow image to be run under a non root user
+RUN sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
+    mkdir /tmp/.nginx && \
+    /bin/bash -e /scripts/add_js_module.sh && \
+    /bin/bash -e /scripts/fix_woff_support.sh && \
+    /bin/bash -e /scripts/set_permissions.sh
+
+RUN goss -g /tests/ubuntu/nginx.goss.yaml validate && \
+    /aufs_hack.sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Provides base OS, patches and stable nginx for quick and easy spinup.
 - Ubuntu used by default
 - Alpine builds available tagged as `-alpine`
 - Centos builds available tagged as `-centos`
+- Ubuntu with ngx_http_js_module tagged as `-njs`
 
 
 [S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation

--- a/container/root/scripts/add_js_module.sh
+++ b/container/root/scripts/add_js_module.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# Add the ngx_http_js_module before the start of the "events {" definition.
+sed -i '\|^events {|{
+  i load_module /usr/lib/nginx/modules/ngx_http_js_module.so;
+  i
+}' /etc/nginx/nginx.conf


### PR DESCRIPTION
This is related to the Adobe item below and a discussion with Jan Michael Ong on dropping the Dockerfile-alpine variant yet still allowing support for the ngx_http_js_module.  This creates a variant of the default/Ubuntu Dockerfile as `Dockerfile-njs` that includes the ngx_http_js_module to support the njs JS-based extension language to nginx.

ETHOS-36876 BBC: Update behance/docker-nginx to use Ubuntu 22.04, deprecate Alpine, update nginx package repo