### PR TITLE
Add X-Client-Ip to log

### DIFF
--- a/container/root/etc/nginx/nginx.conf
+++ b/container/root/etc/nginx/nginx.conf
@@ -94,7 +94,7 @@ http {
 
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for" NGINX_SERVER';
+                    '"$http_user_agent" "$http_x_client_ip" "$http_x_forwarded_for" NGINX_SERVER';
 
     log_format minimal '$request_method $request_uri $status';
 


### PR DESCRIPTION
We are moving towards using special header `X-Client-Ip` to identify client IP instead of relying on X-Forwarded-For header which can be spoofed. Logging X-Client-Ip alongside with X-Forwarded-For to provide the full context of a request

https://jira.corp.adobe.com/browse/COMMUNITY-2323