### PR TITLE
feat(ETHOS-36876): Add new Ubuntu 22.04, Replace nginx installation, Add njs module (ubuntu only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         props:
         - Dockerfile: Dockerfile
+        - Dockerfile: Dockerfile-ubuntu-22.04
         # - Dockerfile: Dockerfile-alpine
         # - Dockerfile: Dockerfile-centos
         platform:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,14 @@ jobs:
         # This is the default variant-less distribution (ex. 3.2.1)
         - Dockerfile: Dockerfile
         # Variant distributions below all have semantic versions + suffix (ex. 3.2.1-alpine)
+        # Alpine is deprecated
         - Dockerfile: Dockerfile-alpine
           suffix: alpine
+        # CentOS is deprecated
         - Dockerfile: Dockerfile-centos
           suffix: centos
+        - Dockerfile: Dockerfile-ubuntu-22.04
+          suffix: ubuntu-22.04
     steps:
       -
         name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,54 @@
-FROM behance/docker-base:5.1.0-ubuntu-22.04 AS base
+FROM behance/docker-base:5.0.1-ubuntu-20.04
 
-### Stage 1 - add/remove packages ###
-
-# Ensure scripts are available for use in next command
-COPY ./container/root/scripts/* /scripts/
-
-# Env vars used during the build process
-ENV CONTAINER_PORT=8080 \
+# Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed
+# Used with alternative CMD (worker.sh), leverages supervisor to maintain long-running processes
+ENV CONTAINER_ROLE=web \
+    CONTAINER_PORT=8080 \
     CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
-    NOT_ROOT_USER=www-data
+    CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
+    NOT_ROOT_USER=www-data \
+    S6_KILL_FINISH_MAXTIME=55000
+
+# Using a non-privileged port to prevent having to use setcap internally
+EXPOSE ${CONTAINER_PORT}
 
 # - Update security packages, plus ca-certificates required for https
-# - Install nginx (see script for details)
+# - Install pre-reqs
+# - Install latest nginx (development PPA is actually mainline development)
+# - Perform cleanup, ensure unnecessary packages are removed
 RUN /bin/bash -e /security_updates.sh && \
-    /bin/bash -e /scripts/install_nginx.sh
+    apt-get install --no-install-recommends -yqq \
+        software-properties-common \
+    && \
+    add-apt-repository ppa:ondrej/nginx -y && \
+    apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        nginx-light \
+        ca-certificates \
+    && \
+    apt-get remove --purge -yq \
+        manpages \
+        manpages-dev \
+        man-db \
+        patch \
+        make \
+        unattended-upgrades \
+        python* \
+    && \
+    /bin/bash -e /clean.sh
 
 # Overlay the root filesystem from this repo
 COPY --chown=www-data ./container/root /
 
 # Set nginx to listen on defined port
-#
-# NOTE: order of operations is important, new config had to already installed
-# from repo (above)
-#
+# NOTE: order of operations is important, new config had to already installed from repo (above)
 # - Make temp directory for .nginx runtime files
 # - Fix woff mime type support
-# - Set permissions to allow image to be run under a non root user
+# Set permissions to allow image to be run under a non root user
 RUN sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
     mkdir /tmp/.nginx && \
     /bin/bash -e /scripts/fix_woff_support.sh && \
     /bin/bash -e /scripts/set_permissions.sh
 
-### Stage 2 --- collapse layers ###
-
-FROM scratch
-COPY --from=base / .
-
-# Using a non-privileged port to prevent having to use setcap internally
-EXPOSE ${CONTAINER_PORT}
-
-# Env vars used during runtime
-ENV CONTAINER_ROLE=web \
-    CONTAINER_PORT=8080 \
-    CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
-    CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
-    NOT_ROOT_USER=www-data
-
-# Use in multi-phase builds, when an init process requests for the container
-# to gracefully exit, so that it may be committed
-#
-# Used with alternative CMD (worker.sh), leverages supervisor to maintain
-# long-running processes
-ENV SIGNAL_BUILD_STOP=99 \
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
-    S6_KILL_FINISH_MAXTIME=55000 \
-    S6_KILL_GRACETIME=3000
-
 RUN goss -g /tests/ubuntu/nginx.goss.yaml validate && \
     /aufs_hack.sh
-
-# NOTE: intentionally NOT using s6 init as the entrypoint
-# This would prevent container debugging if any of those service crash
-CMD ["/bin/bash", "/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,64 @@
-FROM behance/docker-base:5.0.1-ubuntu-20.04
+FROM behance/docker-base:5.1.0-ubuntu-22.04 AS base
 
-# Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed
-# Used with alternative CMD (worker.sh), leverages supervisor to maintain long-running processes
-ENV CONTAINER_ROLE=web \
-    CONTAINER_PORT=8080 \
+### Stage 1 - add/remove packages ###
+
+# Ensure scripts are available for use in next command
+COPY ./container/root/scripts/* /scripts/
+
+# Env vars used during the build process
+ENV CONTAINER_PORT=8080 \
     CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
-    CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
-    NOT_ROOT_USER=www-data \
-    S6_KILL_FINISH_MAXTIME=55000
-
-# Using a non-privileged port to prevent having to use setcap internally
-EXPOSE ${CONTAINER_PORT}
+    NOT_ROOT_USER=www-data
 
 # - Update security packages, plus ca-certificates required for https
-# - Install pre-reqs
-# - Install latest nginx (development PPA is actually mainline development)
-# - Perform cleanup, ensure unnecessary packages are removed
+# - Install nginx (see script for details)
 RUN /bin/bash -e /security_updates.sh && \
-    apt-get install --no-install-recommends -yqq \
-        software-properties-common \
-    && \
-    add-apt-repository ppa:ondrej/nginx -y && \
-    apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        nginx-light \
-        ca-certificates \
-    && \
-    apt-get remove --purge -yq \
-        manpages \
-        manpages-dev \
-        man-db \
-        patch \
-        make \
-        unattended-upgrades \
-        python* \
-    && \
-    /bin/bash -e /clean.sh
+    /bin/bash -e /scripts/install_nginx.sh
 
 # Overlay the root filesystem from this repo
 COPY --chown=www-data ./container/root /
 
 # Set nginx to listen on defined port
-# NOTE: order of operations is important, new config had to already installed from repo (above)
+#
+# NOTE: order of operations is important, new config had to already installed
+# from repo (above)
+#
 # - Make temp directory for .nginx runtime files
 # - Fix woff mime type support
-# Set permissions to allow image to be run under a non root user
+# - Set permissions to allow image to be run under a non root user
 RUN sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
     mkdir /tmp/.nginx && \
     /bin/bash -e /scripts/fix_woff_support.sh && \
     /bin/bash -e /scripts/set_permissions.sh
 
+### Stage 2 --- collapse layers ###
+
+FROM scratch
+COPY --from=base / .
+
+# Using a non-privileged port to prevent having to use setcap internally
+EXPOSE ${CONTAINER_PORT}
+
+# Env vars used during runtime
+ENV CONTAINER_ROLE=web \
+    CONTAINER_PORT=8080 \
+    CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
+    CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
+    NOT_ROOT_USER=www-data
+
+# Use in multi-phase builds, when an init process requests for the container
+# to gracefully exit, so that it may be committed
+#
+# Used with alternative CMD (worker.sh), leverages supervisor to maintain
+# long-running processes
+ENV SIGNAL_BUILD_STOP=99 \
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    S6_KILL_FINISH_MAXTIME=55000 \
+    S6_KILL_GRACETIME=3000
+
 RUN goss -g /tests/ubuntu/nginx.goss.yaml validate && \
     /aufs_hack.sh
+
+# NOTE: intentionally NOT using s6 init as the entrypoint
+# This would prevent container debugging if any of those service crash
+CMD ["/bin/bash", "/run.sh"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,3 +1,7 @@
+################################################################################
+# The AlpineOS flavor is DEPRECATED and will be removed in a future release
+# Please stop using this variant and use the Ubuntu flavor instead
+################################################################################
 FROM behance/docker-base:5.0.1-alpine
 
 # Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,3 +1,7 @@
+################################################################################
+# The CentOS flavor is DEPRECATED and will be removed in a future release
+# Please stop using this variant and use the Ubuntu flavor instead
+################################################################################
 FROM behance/docker-base:5.0.1-centos-7
 
 # Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed

--- a/Dockerfile-ubuntu-22.04
+++ b/Dockerfile-ubuntu-22.04
@@ -1,0 +1,70 @@
+FROM behance/docker-base:5.1.0-ubuntu-22.04 AS base
+
+### Stage 1 - add/remove packages ###
+
+# Ensure scripts are available for use in next command
+COPY ./container/root/scripts/* /scripts/
+
+# Env vars used during the build process
+ENV CONTAINER_PORT=8080 \
+    CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
+    NOT_ROOT_USER=www-data
+
+# - Update security packages, plus ca-certificates required for https
+# - Install nginx
+# - Install njs
+RUN /bin/bash -e /security_updates.sh && \
+    /bin/bash -e /scripts/install_nginx.sh && \
+    /bin/bash -e /scripts/install_njs.sh
+
+# Overlay the root filesystem from this repo
+COPY --chown=www-data ./container/root /
+
+# Set nginx to listen on defined port
+#
+# NOTE: order of operations is important, new config had to already installed
+# from repo (above)
+#
+# - Make temp directory for .nginx runtime files
+# - Fix woff mime type support
+# - Set permissions to allow image to be run under a non root user
+RUN sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
+    mkdir /tmp/.nginx && \
+    /bin/bash -e /scripts/fix_woff_support.sh && \
+    /bin/bash -e /scripts/set_permissions.sh
+
+# Clean up
+RUN /bin/bash -e /scripts/cleanup.sh && \
+    /bin/bash -e /clean.sh
+
+### Stage 2 --- collapse layers ###
+
+FROM scratch
+COPY --from=base / .
+
+# Using a non-privileged port to prevent having to use setcap internally
+EXPOSE ${CONTAINER_PORT}
+
+# Env vars used during runtime
+ENV CONTAINER_ROLE=web \
+    CONTAINER_PORT=8080 \
+    CONF_NGINX_SITE="/etc/nginx/sites-available/default" \
+    CONF_NGINX_SERVER="/etc/nginx/nginx.conf" \
+    NOT_ROOT_USER=www-data
+
+# Use in multi-phase builds, when an init process requests for the container
+# to gracefully exit, so that it may be committed
+#
+# Used with alternative CMD (worker.sh), leverages supervisor to maintain
+# long-running processes
+ENV SIGNAL_BUILD_STOP=99 \
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    S6_KILL_FINISH_MAXTIME=55000 \
+    S6_KILL_GRACETIME=3000
+
+RUN goss -g /tests/ubuntu/nginx.goss.yaml validate && \
+    /aufs_hack.sh
+
+# NOTE: intentionally NOT using s6 init as the entrypoint
+# This would prevent container debugging if any of those service crash
+CMD ["/bin/bash", "/run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: all
+
+IMAGE_NAME ?= docker-nginx
+OS_FAMILY ?= ubuntu-22.04
+PLATFORM ?= linux/amd64
+VERSION ?= test
+
+# Create
+IMAGE_TAG ?= $(VERSION)-$(OS_FAMILY)
+
+default: build
+
+build:
+	docker build --platform $(PLATFORM) -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile-$(OS_FAMILY) .
+
+clean-room:
+	docker system prune -a -f --volumes

--- a/README.md
+++ b/README.md
@@ -8,129 +8,30 @@ Provides base OS, patches and stable nginx for quick and easy spinup.
 - Alpine builds available tagged as `-alpine` **DEPRECATED**
 - Centos builds available tagged as `-centos` **DEPRECATED**
 
-
-[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation
+[S6](https://github.com/just-containers/s6-overlay) process supervisor is used
+for `only` for zombie reaping (as PID 1), boot coordination, and termination
+signal translation
 
 [Goss](https://github.com/aelsabbahy/goss) is used for build-time testing.
 
-See parent(s) [docker-base](https://github.com/behance/docker-base) for additional configuration
+See parent(s) [docker-base](https://github.com/behance/docker-base) for
+additional configuration
 
+# Expectations
 
-### Expectations
+NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
 
-- Applications must copy their html/app into the `/var/www/html` folder
-- Any new script/file that needs to be added must be given proper permissions/ownership to the non root user through `container/root/scripts/set_permissions.sh`. This is to ensure that the image can be run under a non root user.
--   NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
+* Applications must copy their html/app into the `/var/www/html` folder
 
+* Any new script/file that needs to be added must be given proper permissions /
+ownership to the non root user through `container/root/scripts/set_permissions.sh`.
+This is to ensure that the image can be run under a non root user.
 
-### Container Security
+# Docs
 
-See parent [configuration](https://github.com/behance/docker-base#security)
-
-
-### HTTPS usage
-
-To enable this container to serve HTTPS over its primary exposed port:
-- `SERVER_ENABLE_HTTPS` environment variable must be `true`
-- Certificates must be present in `/etc/nginx/certs` under the following names:
-    - `ca.crt`
-    - `ca.key`
-- Additionally, they must be marked read-only (0600)
-
-#### Local development usage
-
-To generate a self-signed certificate (won't work in most browsers):
-```
-openssl genrsa -out ca.key 2048
-openssl req -new -key ca.key -out ca.csr -subj '/CN=localhost'
-openssl x509 -req -days 365 -in ca.csr -signkey ca.key -out ca.crt
-```
-
-Run the image in background, bind external port (443), flag HTTPS enabled, mount certificate:
-```
-docker run \
-  -d
-  -p 443:8080 \
-  -e SERVER_ENABLE_HTTPS=true \
-  -v {directory-containing-ca.crt-and-ca.key}:/etc/nginx/certs:ro
-  behance/docker-nginx
-```
-
-Test
-```
-curl -k -vvv https://{your-docker-machine-ip}
-```
-
-
-### Environment Variables
-
-Variable | Example | Description
---- | --- | ---
-SERVER_MAX_BODY_SIZE | SERVER_MAX_BODY_SIZE=4M | Allows the downstream application to specify a non-default `client_max_body_size` configuration for the `server`-level directive in `/etc/nginx/sites-available/default`
-SERVER_INDEX | SERVER_INDEX index.html index.html index.php | Changes the default pages to hit for folder and web roots
-SERVER_APP_NAME | SERVER_APP_NAME='view' | Gets appended to the default logging format
-SERVER_GZIP_OPTIONS | SERVER_GZIP_OPTIONS=1 | Allows default set of static content to be served gzipped
-SERVER_SENDFILE | SERVER_SENDFILE=off | Allows runtime to specify value of nginx's `sendfile` (default, on)
-SERVER_ENABLE_HTTPS | SERVER_ENABLE_HTTPS=true | Enable encrypted transmission using certificates
-SERVER_KEEPALIVE | SERVER_KEEPALIVE=30 | Define HTTP 1.1's keepalive timeout
-SERVER_WORKER_PROCESSES | SERVER_WORKER_PROCESSES=4 | Set to the number of cores in the machine, or the number of cores allocated to container
-SERVER_WORKER_CONNECTIONS | SERVER_WORKER_CONNECTIONS=2048 | Sets up the number of connections for worker processes
-SERVER_CLIENT_HEADER_BUFFER_SIZE | SERVER_CLIENT_HEADER_BUFFER_SIZE=16k | [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size)
-SERVER_LARGE_CLIENT_HEADER_BUFFERS | SERVER_LARGE_CLIENT_HEADER_BUFFERS=8 16k | [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)
-SERVER_CLIENT_BODY_BUFFER_SIZE | SERVER_CLIENT_BODY_BUFFER_SIZE=128k | [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size)
-SERVER_LOG_MINIMAL | SERVER_LOG_MINIMAL=1 | Minimize the logging format, appropriate for development environments
-S6_KILL_FINISH_MAXTIME | S6_KILL_FINISH_MAXTIME=55000 | The maximum time (in ms) a script in /etc/cont-finish.d could take before sending a KILL signal to it. Take into account that this parameter will be used per each script execution, it's not a max time for the whole set of scripts. This value has a max of 65535 on Alpine variants.
-S6_KILL_GRACETIME | S6_KILL_GRACETIME=500 | Wait time (in ms) for S6 finish scripts before sending kill signal
-
-
-### Startup/Runtime Modification
-
-- Environment variables are used to drive nginx configuration at runtime
-- See [here](https://github.com/behance/docker-base#startupruntime-modification) for more advanced options
-
-### Shutdown Behavior
-
-Graceful shutdown is handled as part of the [existing](https://github.com/behance/docker-base#shutdown-behavior) S6 termination process, using a `/etc/cont-finish.d` script.
-Nginx will attempt to drain active workers, while rejecting new connections. The drain timeout is controlled by `S6_KILL_FINISH_MAXTIME`, which corresponds to the length of time the supervisor will wait for the script to run during shutdown. This value defaults to 55s, which deliberately `less` than an downstream load balancers default max connection length (60s). Each upstream's timeout must be less than the downstream, for sanity and lack of timing precision.
-
-### Long-running processes (workers + crons)
-
-- See parent [configuration](https://github.com/behance/docker-base#long-running-processes-workers--crons) on reusing container for other purposes.
-
-
-### Container Organization
-
-Besides the instructions contained in the Dockerfile, the majority of this
-container's use is in configuration and process. The `./container/root` repo directory is overlayed into a container during build. Adding additional files
-to the folders in there will be present in the final image.
-
-Nginx is currently set up as an S6 service in `/etc/services-available/nginx`, during default environment conditions, it will symlink itself to be supervised under `/etc/services.d/nginx`. When running under worker entrypoint (`worker.sh`), it will not be S6's `service.d` folder to be supervised.
-
-
-### Release Management
-
-Github actions provide the machinery for testing (ci.yaml) and producing tags distributed through Docker Hub (publish.yaml). Testing will confirm that `nginx` is able to serve content in various configurations, but also that it can terminate TLS with self-signed certificates. Once a tested and approved PR is merged, simply cutting a new semantically-versioned tag will generate the following matrix of tagged builds:
-- `[major].[minor].[patch](?-variant)`
-- `[major].[minor](?-variant)`
-- `[major](?-variant)`
-Platform support is available for architectures:
-- `linux/arm64`
-- `linux/amd64`
-
-To add new variant based on a new Dockerfile, add an entry to `matrix.props` within `./github/workflows` YAML files.
-
-### Github Actions: Simulation
-
-docker-nginx uses Github Actions for CI/CD. Simulated workflows can be achieved locally with `act`. All commands must be executes from repository root.
-
-Pre-reqs: tested on Mac
-1. [Docker Desktop](https://www.docker.com/products/docker-desktop)
-1. [act](https://github.com/nektos/act)
-
-Pull request simulation: executes successfully, but only on ARM devices (ex. Apple M1). ARM emulation through QEMU on X64 machines does not implement the full kernel functionality required by nginx at this time.
-- `act pull_request`
-
-Publish simulation: executes, but fails (intentionally) without credentials
-- `act`
-
-
+* [Container Organization](docs/container_organization.md)
+* [Container Security](docs/container_security.md)
+* [Environment Variables](docs/env_vars.md)
+* [Long-running processes (workers + crons)](docs/long_running.md)
+* [Shutdown Behavior](docs/shutdown_behavior.md)
+* [Release Management](docs/release_management.md)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ https://hub.docker.com/r/behance/docker-nginx/tags/
 
 Provides base OS, patches and stable nginx for quick and easy spinup.
 
-- Ubuntu used by default
-- Alpine builds available tagged as `-alpine`
-- Centos builds available tagged as `-centos`
+- Ubuntu 22.04 used by default
+- Alpine builds available tagged as `-alpine` **DEPRECATED**
+- Centos builds available tagged as `-centos` **DEPRECATED**
 
 
 [S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
 ownership to the non root user through `container/root/scripts/set_permissions.sh`.
 This is to ensure that the image can be run under a non root user.
 
+# Quick Start
+
+See [Quick Start](docs/quick_start.md)
+
 # Docs
 
 * [Container Organization](docs/container_organization.md)
@@ -35,3 +39,4 @@ This is to ensure that the image can be run under a non root user.
 * [Long-running processes (workers + crons)](docs/long_running.md)
 * [Shutdown Behavior](docs/shutdown_behavior.md)
 * [Release Management](docs/release_management.md)
+* [Troubleshooting](docs/troubleshooting.md)

--- a/container/root/etc/cont-init.d/10-nginx-config.sh
+++ b/container/root/etc/cont-init.d/10-nginx-config.sh
@@ -83,3 +83,9 @@ then
   # Add SSL to listen directive
   sed -i "s/^[ ]*listen ${CONTAINER_PORT}/  listen ${CONTAINER_PORT} ssl/" $CONF_NGINX_SITE
 fi
+
+if [[ $SERVER_ENABLE_NGX_HTTP_JS ]];
+then
+  echo "[nginx] enabling nginx njs module"
+  sed -i "s/#load_module/load_module/" $CONF_NGINX_SERVER
+fi

--- a/container/root/etc/nginx/nginx.conf
+++ b/container/root/etc/nginx/nginx.conf
@@ -19,6 +19,9 @@ error_log /dev/stdout warn;
 # Number of file descriptors used for nginx
 worker_rlimit_nofile 40000;
 
+# Set SERVER_ENABLE_NGX_HTTP_JS=true to enable this module
+#load_module /usr/lib/nginx/modules/ngx_http_js_module.so;
+
 
 events {
     # Optimized to serve many clients with each thread, essential for linux

--- a/container/root/scripts/cleanup.sh
+++ b/container/root/scripts/cleanup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+###############################################################################
+# Remove any uneeded packages that we install that is not during runtime
+###############################################################################
+
+# Running python will generate .pyc files and it will prevent the folder
+# from being deleted. Sample warning:
+#
+# dpkg: warning: while removing python3.10, 
+# directory '/usr/lib/python3/dist-packages' not empty so not removed
+[[ -d /usr/lib/python3/dist-packages ]] && rm -rf /usr/lib/python3/dist-packages
+
+# Remove unused packages that should not be in the final image
+apt-get remove --purge -yq \
+  curl \
+  gnupg2 \
+  lsb-release \
+  manpages \
+  manpages-dev \
+  man-db \
+  patch \
+  make \
+  unattended-upgrades \
+  python*

--- a/container/root/scripts/fix_woff_support.sh
+++ b/container/root/scripts/fix_woff_support.sh
@@ -4,7 +4,12 @@
 sed -i "/application\/font-woff/d" /etc/nginx/mime.types
 
 # Detects if woff support is already present
-if grep -Fxq "font/woff" /etc/nginx/mime.types
+# From: https://linux.die.net/man/1/grep
+# -F - Interpret PATTERN as a list of fixed strings, separated by newlines, 
+#      any of which is to be matched
+# -q - Quiet; do not write anything to standard output. Exit immediately with
+#      zero status if any match is found, even if an error was detected
+if grep -Fq "font/woff" /etc/nginx/mime.types
 then
   echo "Woff type detected, no changes necessary"
 else

--- a/container/root/scripts/install_nginx.sh
+++ b/container/root/scripts/install_nginx.sh
@@ -1,9 +1,11 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
+###############################################################################
 # Install nginx per http://nginx.org/en/linux_packages.html#Ubuntu
+###############################################################################
 
-# Install the prerequisites: 
-apt -y update && apt -y install \
+# Install the prerequisites
+apt-get -y install \
   curl \
   gnupg2 \
   ca-certificates \
@@ -29,21 +31,5 @@ echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 
     | tee /etc/apt/preferences.d/99nginx
 
 # Install nginx
-apt -y update && apt -y install nginx-light
-
-# Cleanup
-# Otherwise dpkg will complain with
-# dpkg: warning: while removing python3.10, directory '/usr/lib/python3/dist-packages' not empty so not removed
-rm -rf /usr/lib/python3/dist-packages
-
-apt-get remove --purge -yq \
-  curl \
-  gnupg2 \
-  lsb-release \
-  manpages \
-  manpages-dev \
-  man-db \
-  patch \
-  make \
-  unattended-upgrades \
-  python*
+apt-get -y update && apt-get -y install \
+  nginx-light

--- a/container/root/scripts/install_nginx.sh
+++ b/container/root/scripts/install_nginx.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+
+# Install nginx per http://nginx.org/en/linux_packages.html#Ubuntu
+
+# Install the prerequisites: 
+apt -y update && apt -y install \
+  curl \
+  gnupg2 \
+  ca-certificates \
+  lsb-release \
+  ubuntu-keyring
+
+# Import an official nginx signing key so apt could verify the packages
+# authenticity. Fetch the key: 
+curl -s https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
+    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+
+gpg --dry-run --quiet --import --import-options import-show \
+  /usr/share/keyrings/nginx-archive-keyring.gpg
+
+# set up the apt repository for stable nginx packages
+echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+  http://nginx.org/packages/ubuntu `lsb_release -cs` nginx" \
+    | tee /etc/apt/sources.list.d/nginx.list
+
+# Set up repository pinning to prefer our packages over
+# distribution-provided ones:
+echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" \
+    | tee /etc/apt/preferences.d/99nginx
+
+# Install nginx
+apt -y update && apt -y install nginx-light
+
+# Cleanup
+# Otherwise dpkg will complain with
+# dpkg: warning: while removing python3.10, directory '/usr/lib/python3/dist-packages' not empty so not removed
+rm -rf /usr/lib/python3/dist-packages
+
+apt-get remove --purge -yq \
+  curl \
+  gnupg2 \
+  lsb-release \
+  manpages \
+  manpages-dev \
+  man-db \
+  patch \
+  make \
+  unattended-upgrades \
+  python*

--- a/container/root/scripts/install_njs.sh
+++ b/container/root/scripts/install_njs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+###############################################################################
+# Install nginx NJS module
+# Ref: https://nginx.org/en/docs/njs/install.html
+###############################################################################
+
+# https://jira.corp.adobe.com/browse/ETHOS-36876
+apt-get -y update && \
+    apt-get -y \
+        -o Dpkg::Options::="--force-confdef" \
+        -o Dpkg::Options::="--force-confold" \
+        install nginx-module-njs
+
+# Remove any debug packags
+rm /etc/nginx/modules/ngx_*-debug.so

--- a/docs/container_organization.md
+++ b/docs/container_organization.md
@@ -1,0 +1,7 @@
+# Container Organization
+
+Besides the instructions contained in the Dockerfile, the majority of this
+container's use is in configuration and process. The `./container/root` repo directory is overlayed into a container during build. Adding additional files
+to the folders in there will be present in the final image.
+
+Nginx is currently set up as an S6 service in `/etc/services-available/nginx`, during default environment conditions, it will symlink itself to be supervised under `/etc/services.d/nginx`. When running under worker entrypoint (`worker.sh`), it will not be S6's `service.d` folder to be supervised.

--- a/docs/container_security.md
+++ b/docs/container_security.md
@@ -1,0 +1,3 @@
+# Container Security
+
+See parent [configuration](https://github.com/behance/docker-base#security)

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -1,0 +1,27 @@
+# Environment Variables
+
+Supported env vars
+
+Variable | Example | Description
+--- | --- | ---
+SERVER_MAX_BODY_SIZE | SERVER_MAX_BODY_SIZE=4M | Allows the downstream application to specify a non-default `client_max_body_size` configuration for the `server`-level directive in `/etc/nginx/sites-available/default`
+SERVER_INDEX | SERVER_INDEX index.html index.html index.php | Changes the default pages to hit for folder and web roots
+SERVER_APP_NAME | SERVER_APP_NAME='view' | Gets appended to the default logging format
+SERVER_GZIP_OPTIONS | SERVER_GZIP_OPTIONS=1 | Allows default set of static content to be served gzipped
+SERVER_SENDFILE | SERVER_SENDFILE=off | Allows runtime to specify value of nginx's `sendfile` (default, on)
+SERVER_ENABLE_HTTPS | SERVER_ENABLE_HTTPS=true | Enable encrypted transmission using certificates
+SERVER_KEEPALIVE | SERVER_KEEPALIVE=30 | Define HTTP 1.1's keepalive timeout
+SERVER_WORKER_PROCESSES | SERVER_WORKER_PROCESSES=4 | Set to the number of cores in the machine, or the number of cores allocated to container
+SERVER_WORKER_CONNECTIONS | SERVER_WORKER_CONNECTIONS=2048 | Sets up the number of connections for worker processes
+SERVER_CLIENT_HEADER_BUFFER_SIZE | SERVER_CLIENT_HEADER_BUFFER_SIZE=16k | [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size)
+SERVER_LARGE_CLIENT_HEADER_BUFFERS | SERVER_LARGE_CLIENT_HEADER_BUFFERS=8 16k | [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)
+SERVER_CLIENT_BODY_BUFFER_SIZE | SERVER_CLIENT_BODY_BUFFER_SIZE=128k | [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size)
+SERVER_LOG_MINIMAL | SERVER_LOG_MINIMAL=1 | Minimize the logging format, appropriate for development environments
+S6_KILL_FINISH_MAXTIME | S6_KILL_FINISH_MAXTIME=55000 | The maximum time (in ms) a script in /etc/cont-finish.d could take before sending a KILL signal to it. Take into account that this parameter will be used per each script execution, it's not a max time for the whole set of scripts. This value has a max of 65535 on Alpine variants.
+S6_KILL_GRACETIME | S6_KILL_GRACETIME=500 | Wait time (in ms) for S6 finish scripts before sending kill signal
+
+## Startup/Runtime Modification
+
+- Environment variables are used to drive nginx configuration at runtime
+- See [here](https://github.com/behance/docker-base#startupruntime-modification) for more advanced options
+

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -10,6 +10,7 @@ SERVER_APP_NAME | SERVER_APP_NAME='view' | Gets appended to the default logging 
 SERVER_GZIP_OPTIONS | SERVER_GZIP_OPTIONS=1 | Allows default set of static content to be served gzipped
 SERVER_SENDFILE | SERVER_SENDFILE=off | Allows runtime to specify value of nginx's `sendfile` (default, on)
 SERVER_ENABLE_HTTPS | SERVER_ENABLE_HTTPS=true | Enable encrypted transmission using certificates
+SERVER_ENABLE_NGX_HTTP_JS | SERVER_ENABLE_NGX_HTTP_JS=true | Enable nginx njs module (default, false)
 SERVER_KEEPALIVE | SERVER_KEEPALIVE=30 | Define HTTP 1.1's keepalive timeout
 SERVER_WORKER_PROCESSES | SERVER_WORKER_PROCESSES=4 | Set to the number of cores in the machine, or the number of cores allocated to container
 SERVER_WORKER_CONNECTIONS | SERVER_WORKER_CONNECTIONS=2048 | Sets up the number of connections for worker processes

--- a/docs/https_usage.md
+++ b/docs/https_usage.md
@@ -1,0 +1,116 @@
+# HTTPS usage
+
+To enable this container to serve HTTPS over its primary exposed port:
+- `SERVER_ENABLE_HTTPS` environment variable must be `true`
+- Certificates must be present in `/etc/nginx/certs` under the following names:
+    - `ca.crt`
+    - `ca.key`
+- Additionally, they must be marked read-only (0600)
+
+## Local development usage
+
+To generate a self-signed certificate (won't work in most browsers):
+```
+openssl genrsa -out ca.key 2048
+openssl req -new -key ca.key -out ca.csr -subj '/CN=localhost'
+openssl x509 -req -days 365 -in ca.csr -signkey ca.key -out ca.crt
+mkdir -p certs/
+cp ca.* certs/
+```
+
+Run the image, bind external port (443), flag HTTPS enabled, mount certificate:
+
+```
+docker run \
+  -it
+  -p 443:8080 \
+  -e SERVER_ENABLE_HTTPS=true \
+  -v $(pwd)/certs:/etc/nginx/certs:ro
+  behance/docker-nginx
+```
+
+<details><summary>Click to show sample output</summary>
+
+  $ docker run -it -p 443:8080 -e SERVER_ENABLE_HTTPS=true -v /Users/jmong/git/forks/docker-nginx/certs:/etc/nginx/certs:ro docker-nginx:test2
+  [init] executing /run.d/99-nginx.sh
+  [run] enabling web server
+  [run] starting process manager
+  [s6-init] making user provided files available at /var/run/s6/etc...exited 0.
+  [s6-init] ensuring user provided files have correct perms...exited 0.
+  [fix-attrs.d] applying ownership & permissions fixes...
+  [fix-attrs.d] done.
+  [cont-init.d] executing container initialization scripts...
+  [cont-init.d] 10-nginx-config.sh: executing... 
+  [nginx] missing $SERVER_APP_NAME to add to log lines, please add environment variable
+  [nginx] enabling HTTPS
+  [cont-init.d] 10-nginx-config.sh: exited 0.
+  [cont-init.d] 11-nginx-validation.sh: executing... 
+  [cont-init.d] 11-nginx-validation.sh: exited 0.
+  [cont-init.d] done.
+  [services.d] starting services
+  [services.d] done.
+
+</details>
+
+Test
+```
+curl -k -vvv https://{your-docker-machine-ip}
+```
+
+<details><summary>Click to show sample output</summary>
+
+  $ curl -k -vvv https://127.0.0.1/
+  *   Trying 127.0.0.1...
+  * TCP_NODELAY set
+  * Connected to 127.0.0.1 (127.0.0.1) port 443 (#0)
+  * ALPN, offering h2
+  * ALPN, offering http/1.1
+  * successfully set certificate verify locations:
+  *   CAfile: /etc/ssl/cert.pem
+    CApath: none
+  * TLSv1.2 (OUT), TLS handshake, Client hello (1):
+  * TLSv1.2 (IN), TLS handshake, Server hello (2):
+  * TLSv1.2 (IN), TLS handshake, Certificate (11):
+  * TLSv1.2 (IN), TLS handshake, Server key exchange (12):
+  * TLSv1.2 (IN), TLS handshake, Server finished (14):
+  * TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
+  * TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
+  * TLSv1.2 (OUT), TLS handshake, Finished (20):
+  * TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
+  * TLSv1.2 (IN), TLS handshake, Finished (20):
+  * SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
+  * ALPN, server accepted to use http/1.1
+  * Server certificate:
+  *  subject: CN=localhost
+  *  start date: Jul 15 01:48:05 2022 GMT
+  *  expire date: Jul 15 01:48:05 2023 GMT
+  *  issuer: CN=localhost
+  *  SSL certificate verify result: self signed certificate (18), continuing anyway.
+  > GET / HTTP/1.1
+  > Host: 127.0.0.1
+  > User-Agent: curl/7.64.1
+  > Accept: */*
+  > 
+  < HTTP/1.1 200 OK
+  < Server: nginx
+  < Date: Fri, 15 Jul 2022 01:54:00 GMT
+  < Content-Type: text/html
+  < Content-Length: 633
+  < Last-Modified: Fri, 15 Jul 2022 00:33:23 GMT
+  < Connection: keep-alive
+  < ETag: "62d0b5d3-279"
+  < X-XSS-Protection: 1; mode=block
+  < X-Content-Type-Options: nosniff
+  < Accept-Ranges: bytes
+  < 
+  <!DOCTYPE html>
+  <html>
+  <head>
+  <title>Welcome to nginx!</title>
+  [...snip...]
+  <h1>It Works!</h1>
+  * Connection #0 to host 127.0.0.1 left intact
+  * Closing connection 0
+
+</details>
+

--- a/docs/long_running.md
+++ b/docs/long_running.md
@@ -1,0 +1,6 @@
+# Long-running processes (workers + crons)
+
+- See parent [configuration](https://github.com/behance/docker-base#long-running-processes-workers--crons) on reusing container for other purposes.
+
+
+

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,0 +1,19 @@
+# Quick Start
+
+1. Fork and clone the git repo
+1. cd into `docker-nginx` and run `make`
+    ```
+    make
+
+    # Or if you're on an ARM machine i.e. M1, do
+    VERSION=arm64 PLATFORM=linux/arm64 make
+    ```
+1. Wait for the build to complete
+1. Once the build completes, start up the image as:
+    ```
+    docker run -it -e SERVER_APP_NAME=hello -p 8080:8080 docker-nginx
+    ```
+1. Curl your endpoint
+    ```
+    curl http://127.0.0.1:8080/
+    ```

--- a/docs/release_management.md
+++ b/docs/release_management.md
@@ -1,0 +1,25 @@
+# Release Management
+
+Github actions provide the machinery for testing (ci.yaml) and producing tags distributed through Docker Hub (publish.yaml). Testing will confirm that `nginx` is able to serve content in various configurations, but also that it can terminate TLS with self-signed certificates. Once a tested and approved PR is merged, simply cutting a new semantically-versioned tag will generate the following matrix of tagged builds:
+- `[major].[minor].[patch](?-variant)`
+- `[major].[minor](?-variant)`
+- `[major](?-variant)`
+Platform support is available for architectures:
+- `linux/arm64`
+- `linux/amd64`
+
+To add new variant based on a new Dockerfile, add an entry to `matrix.props` within `./github/workflows` YAML files.
+
+## Github Actions: Simulation
+
+docker-nginx uses Github Actions for CI/CD. Simulated workflows can be achieved locally with `act`. All commands must be executes from repository root.
+
+Pre-reqs: tested on Mac
+1. [Docker Desktop](https://www.docker.com/products/docker-desktop)
+1. [act](https://github.com/nektos/act)
+
+Pull request simulation: executes successfully, but only on ARM devices (ex. Apple M1). ARM emulation through QEMU on X64 machines does not implement the full kernel functionality required by nginx at this time.
+- `act pull_request`
+
+Publish simulation: executes, but fails (intentionally) without credentials
+- `act`

--- a/docs/shutdown_behavior.md
+++ b/docs/shutdown_behavior.md
@@ -1,0 +1,5 @@
+# Shutdown Behavior
+
+Graceful shutdown is handled as part of the [existing](https://github.com/behance/docker-base#shutdown-behavior) S6 termination process, using a `/etc/cont-finish.d` script.
+Nginx will attempt to drain active workers, while rejecting new connections. The drain timeout is controlled by `S6_KILL_FINISH_MAXTIME`, which corresponds to the length of time the supervisor will wait for the script to run during shutdown. This value defaults to 55s, which deliberately `less` than an downstream load balancers default max connection length (60s). Each upstream's timeout must be less than the downstream, for sanity and lack of timing precision.
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting
+
+* [io_setup() failed](#iosetup-failed)
+
+## io_setup failed
+
+**Symptom**
+
+During start up, you see:
+
+```shell
+cont-init.d] done.
+[services.d] starting services
+2022/07/15 14:48:57 [emerg] 1015#1015: io_setup() failed (38: Function not implemented)
+2022/07/15 14:48:57 [emerg] 1017#1017: io_setup() failed (38: Function not implemented)
+2022/07/15 14:48:57 [emerg] 1019#1019: io_setup() failed (38: Function not implemented)
+2022/07/15 14:48:57 [emerg] 1020#1020: io_setup() failed (38: Function not implemented)
+[services.d] done.
+```
+
+**Resolution**
+
+You might be running docker with emulation i.e. `docker run --platform linux/amd64`.
+
+If so, you need to run it natively on an ARM64 computer. See [StackOverflow](https://stackoverflow.com/questions/68704538/error-io-setup-failed-38-function-not-implemented-in-nginx-for-arm-m1)

--- a/tests/njs/Dockerfile
+++ b/tests/njs/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker-nginx:njs
+
+COPY ./root/etc /etc

--- a/tests/njs/Makefile
+++ b/tests/njs/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build
+
+# Name of the image to build
+IMAGE_TAG=docker-nginx:njs
+
+default: build
+
+build-src:
+	cd ../.. && docker build -t $(IMAGE_TAG) -f Dockerfile-ubuntu-22.04 .
+
+build: build-src
+	docker build -t $(IMAGE_TAG)-test -f Dockerfile .
+
+dgoss: build
+	GOSS_WAIT_OPTS="-r 60s -s 5s > /dev/null" dgoss run -e SERVER_ENABLE_NGX_HTTP_JS=true -p 8080:8080 $(IMAGE_TAG)-test
+

--- a/tests/njs/README.md
+++ b/tests/njs/README.md
@@ -1,0 +1,16 @@
+njs
+====
+
+This is a simple dgoss test to validate that the njs module is running.
+
+To test:
+
+1. cd `tests/njs`
+1. Run `make dgoss`
+
+Behind the scenes, it builds the `njs`-enabled docker image, then builds
+a test image and copies over some test files
+
+Finally, it runs `dgoss` and checks the `njs` enabled endpoint.
+
+The script assumes that you have `dgoss` installed. 

--- a/tests/njs/goss.yaml
+++ b/tests/njs/goss.yaml
@@ -1,0 +1,8 @@
+http:
+  http://localhost:8080/hello_njs:
+    status: 200
+    allow-insecure: true
+    timeout: 5000
+    body:
+      - Hello there!
+

--- a/tests/njs/goss_wait.yaml
+++ b/tests/njs/goss_wait.yaml
@@ -1,0 +1,5 @@
+file:
+  /goss/docker_output.log:
+    exists: true
+    contains:
+      - 'enabling nginx njs module'

--- a/tests/njs/root/etc/nginx/sites-available/default
+++ b/tests/njs/root/etc/nginx/sites-available/default
@@ -1,0 +1,33 @@
+js_path /etc/nginx/sites;
+js_import all_js from sites/all.mjs;
+
+server {
+  listen 8080;
+
+  root /var/www/html;
+
+  # Doesn't broadcast version level of server software
+  server_tokens off;
+
+  # Replace with env variable SERVER_INDEX
+  index index.html index.htm;
+
+  # Replace with env variable SERVER_MAX_BODY_SIZE
+  client_max_body_size 1m;
+
+  location / {
+    try_files $uri $uri/ =404;
+  }
+
+  # Protect against accessing hidden files, except for files living under .well-known
+  # @see https://www.ietf.org/rfc/rfc5785.txt
+  location ~ /\.(?!well-known/) {
+    access_log off;
+    log_not_found off;
+    deny all;
+  }
+
+  location /hello_njs {
+    js_content all_js.hello;
+  }
+}

--- a/tests/njs/root/etc/nginx/sites/all.mjs
+++ b/tests/njs/root/etc/nginx/sites/all.mjs
@@ -1,0 +1,8 @@
+function hello(req) {
+  req.headersOut['Content-Type'] = 'text/plain';
+  req.return(200, 'Hello there!');
+}
+
+export default {
+  hello
+}


### PR DESCRIPTION
# What changed?

## Major Changes

* Add new base from Ubuntu 20.04 (`docker-base:5.0.1-ubuntu-20.04`) to Ubuntu 22.04 (`docker-base:5.1.0-ubuntu-22.04`). Will eventually make this the default
* Removed previous nginx installation from `ppa:ondrej/nginx` and `software-properties-common`
* Removed `curl`, `gnupg2` if installed
* Added new install nginx script `scripts/install_nginx.sh`,  from standard nginx install: http://nginx.org/en/linux_packages.html#Ubuntu
* Added new install njs module script `scripts/install_njs.sh` to install `nginx-module-njs` module. See ETHOS-36876 @kmashint - https://nginx.org/en/docs/njs/
* Added new cleanup script `scripts/cleanup.sh` to purge unnecessary packages in final image
* Added `SERVER_ENABLE_NGX_HTTP_JS`. If set to `true`, it will enable i.e. `load_module` the nginx njs module
* Updated Ubuntu Dockerfile to use multi-stage builds

## Bug Fixes

* Fix `duplicate extension` warning due to grep `-x` not matching any previous entries. Sample error
  ```sh
  nginx: [warn] duplicate extension "woff", content type: "font/woff", previous content type: "font/woff" in /etc/nginx/mime.types:100
  nginx: [warn] duplicate extension "woff2", content type: "font/woff2", previous content type: "font/woff2" in /etc/nginx/mime.types:101
  ```

## Doc Changes

* Add deprecated messages to Alpine, CentOS
* Move most of the docs to `docs/`
* Add additional output in `docs/` when testing HTTPS usage locally
* Add quickstart
* Add troubleshooting

## CI Changes

* Updated ci and publish jobs to build the new image with `-ubuntu-22.04` tag

## Other Changes

* Add `Makefile` for common local dev operations

# Additional data

## Nginx Package Versions

As of Jul 15, 2022, these are the versions that it builds with:

  ```
  ii  nginx                       1.22.0-1~jammy                          amd64        high performance web server
  ii  nginx-module-njs            1.22.0+0.7.5-1~jammy                    amd64        nginx njs dynamic modules
  ```

## Steps to build locally

1. Clone fork
  ```sh
  cd /tmp
  git clone git@github.com:adobejmong/docker-nginx.git
  cd docker-nginx
  git checkout ETHOS-36876
  ```
2. Build it locally
  ```sh
  # Builds an AMD64 image
  make
  
  # To build an ARM64 image
  VERSION=arm64 PLATFORM=linux/arm64 make
  ```

## Steps to test locally

To test the `njs` module, I worked with @kmashint to create a simple test. The test assumes that you have `dgoss` installed.

```
cd tests/njs
make dgoss
```

Sample output:

```
GOSS_WAIT_OPTS="-r 60s -s 5s > /dev/null" dgoss run -e SERVER_ENABLE_NGX_HTTP_JS=true -p 8080:8080 docker-nginx:njs-test
INFO: Starting docker container
INFO: Container ID: e2e48808
INFO: Found goss_wait.yaml, waiting for it to pass before running tests
INFO: Sleeping for 0.2
INFO: Container health
INFO: Running Tests
HTTP: http://localhost:8080/hello_njs: status: matches expectation: [200]
HTTP: http://localhost:8080/hello_njs: Body: matches expectation: [Hello there!]


Total Duration: 0.013s
Count: 2, Failed: 0, Skipped: 0
INFO: Deleting container
```

## Image Size comparison

Use `docker images` or `docker inspect` for the `linux/amd64` architecture:

|  Image                                           | Size (in MB)     |
| -------------------------------- | -------------- |
| Original (docker-nginx:10.0.0)     |  115                  |
| Without NJS                                 |  102                  |
| With NJS                                       |  103                  |
